### PR TITLE
Add db and basic list

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 28
-
 
     defaultConfig {
         applicationId "com.patientchat.androidapp"
@@ -23,10 +23,8 @@ android {
         }
     }
 
-// To inline the bytecode built with JVM target 1.8 into
-// bytecode that is being built with JVM target 1.6. (e.g. navArgs)
-
-
+    // To inline the bytecode built with JVM target 1.8 into
+    // bytecode that is being built with JVM target 1.6. (e.g. navArgs)
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -35,27 +33,45 @@ android {
         jvmTarget = "1.8"
     }
 
+    packagingOptions {
+        exclude 'META-INF/atomicfu.kotlin_module'
+    }
+
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.2.0'
-    implementation 'com.google.android.material:material:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.2.1'
     implementation 'androidx.navigation:navigation-ui-ktx:2.2.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
+
+    // Kotlin components
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    api "org.jetbrains.kotlinx:kotlinx-coroutines-core:$rootProject.coroutines"
+    api "org.jetbrains.kotlinx:kotlinx-coroutines-android:$rootProject.coroutines"
+
+    // Material design
+    implementation "com.google.android.material:material:$rootProject.materialVersion"
+
+    // Room components
+    implementation "androidx.room:room-runtime:$rootProject.roomVersion"
+    implementation "androidx.room:room-ktx:$rootProject.roomVersion"
+    kapt "androidx.room:room-compiler:$rootProject.roomVersion"
+    androidTestImplementation "androidx.room:room-testing:$rootProject.roomVersion"
+
+    // Lifecycle components
+    implementation "androidx.lifecycle:lifecycle-extensions:$rootProject.archLifecycleVersion"
+    kapt "androidx.lifecycle:lifecycle-compiler:$rootProject.archLifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$rootProject.archLifecycleVersion"
+    implementation 'androidx.fragment:fragment-ktx:1.1.0' // for using view models in fragments
+
+    // Testing
     testImplementation 'junit:junit:4.12'
+    androidTestImplementation "androidx.arch.core:core-testing:$rootProject.coreTestingVersion"
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-
-    // room
-    def room_version = "2.2.5"
-    implementation "androidx.room:room-runtime:$room_version"
-    annotationProcessor "androidx.room:room-compiler:$room_version"
-    implementation "androidx.room:room-ktx:$room_version"
-    testImplementation "androidx.room:room-testing:$room_version"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:name=".MainActivity"
+            android:name=".features.MainActivity"
             android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>

--- a/app/src/main/java/com/patientchat/androidapp/core/PatientChatUtils.kt
+++ b/app/src/main/java/com/patientchat/androidapp/core/PatientChatUtils.kt
@@ -1,0 +1,16 @@
+package com.patientchat.androidapp.core
+
+import android.app.Activity
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+import androidx.core.content.ContextCompat.getSystemService
+
+
+class PatientChatUtils {
+    companion object {
+        public fun hideKeyboard(view: View) {
+            val inputMethodManager = view.context!!.getSystemService(android.content.Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+            inputMethodManager?.hideSoftInputFromWindow(view.windowToken, 0)
+        }
+    }
+}

--- a/app/src/main/java/com/patientchat/androidapp/core/PatientRepository.kt
+++ b/app/src/main/java/com/patientchat/androidapp/core/PatientRepository.kt
@@ -1,0 +1,13 @@
+package com.patientchat.androidapp.core
+
+import androidx.lifecycle.LiveData
+import com.patientchat.androidapp.core.db.Patient
+import com.patientchat.androidapp.core.db.PatientDoa
+
+class PatientRepository(private val patientDoa: PatientDoa) {
+    val allPatients: LiveData<List<Patient>> = patientDoa.getAlphabetizedWords()
+
+    suspend fun insert(patient: Patient) {
+        patientDoa.insert(patient)
+    }
+}

--- a/app/src/main/java/com/patientchat/androidapp/core/PatientRepository.kt
+++ b/app/src/main/java/com/patientchat/androidapp/core/PatientRepository.kt
@@ -10,4 +10,8 @@ class PatientRepository(private val patientDoa: PatientDoa) {
     suspend fun insert(patient: Patient) {
         patientDoa.insert(patient)
     }
+
+    suspend fun deleteAll() {
+        patientDoa.deleteAll()
+    }
 }

--- a/app/src/main/java/com/patientchat/androidapp/core/PatientViewModel.kt
+++ b/app/src/main/java/com/patientchat/androidapp/core/PatientViewModel.kt
@@ -1,0 +1,25 @@
+package com.patientchat.androidapp.core
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.viewModelScope
+import com.patientchat.androidapp.core.db.Patient
+import com.patientchat.androidapp.core.db.PatientChatDatabase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class PatientViewModel(application: Application) : AndroidViewModel(application) {
+    private val repository: PatientRepository
+    val allPatients: LiveData<List<Patient>>
+
+    init {
+        val patientDoa = PatientChatDatabase.getDatabase(application).patientDao()
+        repository = PatientRepository(patientDoa)
+        allPatients = repository.allPatients
+    }
+
+    fun insert(patient: Patient) = viewModelScope.launch(Dispatchers.IO) {
+        repository.insert(patient)
+    }
+}

--- a/app/src/main/java/com/patientchat/androidapp/core/PatientViewModel.kt
+++ b/app/src/main/java/com/patientchat/androidapp/core/PatientViewModel.kt
@@ -22,4 +22,8 @@ class PatientViewModel(application: Application) : AndroidViewModel(application)
     fun insert(patient: Patient) = viewModelScope.launch(Dispatchers.IO) {
         repository.insert(patient)
     }
+
+    fun deleteAll() = viewModelScope.launch(Dispatchers.IO) {
+        repository.deleteAll()
+    }
 }

--- a/app/src/main/java/com/patientchat/androidapp/core/db/Patient.kt
+++ b/app/src/main/java/com/patientchat/androidapp/core/db/Patient.kt
@@ -1,11 +1,11 @@
-package com.patientchat.androidapp.db
+package com.patientchat.androidapp.core.db
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
-@Entity
-data class Patient(@PrimaryKey val name: String,
+@Entity(tableName = "patient_table")
+data class Patient(@PrimaryKey @ColumnInfo(name = "name") val name: String,
                    @ColumnInfo(name = "ssid") val ssid: String?,
                    @ColumnInfo(name = "password") val password: String?) {
 

--- a/app/src/main/java/com/patientchat/androidapp/core/db/PatientChatDatabase.kt
+++ b/app/src/main/java/com/patientchat/androidapp/core/db/PatientChatDatabase.kt
@@ -1,0 +1,34 @@
+package com.patientchat.androidapp.core.db
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import kotlinx.coroutines.CoroutineScope
+
+// TODO: set directory for Room ot use to export schema
+@Database(entities = [Patient::class], version = 1, exportSchema = false)
+public abstract class PatientChatDatabase : RoomDatabase() {
+
+    abstract fun patientDao(): PatientDoa
+
+    companion object {
+        @Volatile
+        private var INSTANCE: PatientChatDatabase? = null
+
+        fun getDatabase(context: Context): PatientChatDatabase {
+            val tempInstance = INSTANCE
+            if (tempInstance != null) return tempInstance
+            synchronized(this) {
+                val instance = Room.databaseBuilder(
+                    context.applicationContext,
+                    PatientChatDatabase::class.java,
+                    "patient_chat_database"
+                ).build()
+                INSTANCE = instance
+                return instance
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/patientchat/androidapp/core/db/PatientDoa.kt
+++ b/app/src/main/java/com/patientchat/androidapp/core/db/PatientDoa.kt
@@ -1,0 +1,20 @@
+package com.patientchat.androidapp.core.db
+
+import androidx.lifecycle.LiveData
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface PatientDoa {
+
+    @Query("SELECT * from patient_table ORDER BY name ASC")
+    fun getAlphabetizedWords(): LiveData<List<Patient>>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insert(word: Patient)
+
+    @Query("DELETE FROM patient_table")
+    suspend fun deleteAll()
+}

--- a/app/src/main/java/com/patientchat/androidapp/db/PatientDoa.kt
+++ b/app/src/main/java/com/patientchat/androidapp/db/PatientDoa.kt
@@ -1,2 +1,0 @@
-package com.patientchat.androidapp.db
-

--- a/app/src/main/java/com/patientchat/androidapp/features/MainActivity.kt
+++ b/app/src/main/java/com/patientchat/androidapp/features/MainActivity.kt
@@ -1,37 +1,38 @@
-package com.patientchat.androidapp
+package com.patientchat.androidapp.features
 
 import android.os.Bundle
-import com.google.android.material.snackbar.Snackbar
 import androidx.appcompat.app.AppCompatActivity
 import android.view.Menu
 import android.view.MenuItem
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
+import com.patientchat.androidapp.R
+import com.patientchat.androidapp.core.PatientViewModel
 
 import kotlinx.android.synthetic.main.activity_main.*
 
 class MainActivity : AppCompatActivity() {
+
+    private lateinit var patientViewModel: PatientViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
         setSupportActionBar(toolbar)
 
-        // todo: show fab if 1+ patient
-//        fab.setOnClickListener { view ->
-//            Snackbar.make(view, "TODO: Add new patient", Snackbar.LENGTH_LONG)
-//                    .setAction("Action", null).show()
-//        }
+        patientViewModel = ViewModelProvider(this).get(PatientViewModel::class.java)
+        patientViewModel.allPatients.observe(this, Observer { patients ->
+
+//            patients?.let { adapter.setPatients(it) }
+        })
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
-        // Inflate the menu; this adds items to the action bar if it is present.
         menuInflater.inflate(R.menu.menu_main, menu)
         return true
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        // Handle action bar item clicks here. The action bar will
-        // automatically handle clicks on the Home/Up button, so long
-        // as you specify a parent activity in AndroidManifest.xml.
         return when (item.itemId) {
             R.id.action_settings -> true
             else -> super.onOptionsItemSelected(item)

--- a/app/src/main/java/com/patientchat/androidapp/features/MainActivity.kt
+++ b/app/src/main/java/com/patientchat/androidapp/features/MainActivity.kt
@@ -21,10 +21,6 @@ class MainActivity : AppCompatActivity() {
         setSupportActionBar(toolbar)
 
         patientViewModel = ViewModelProvider(this).get(PatientViewModel::class.java)
-        patientViewModel.allPatients.observe(this, Observer { patients ->
-
-//            patients?.let { adapter.setPatients(it) }
-        })
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -34,6 +30,10 @@ class MainActivity : AppCompatActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
+            R.id.action_clear_patients -> {
+                patientViewModel.deleteAll()
+                true
+            }
             R.id.action_settings -> true
             else -> super.onOptionsItemSelected(item)
         }

--- a/app/src/main/java/com/patientchat/androidapp/features/WelcomeFragment.kt
+++ b/app/src/main/java/com/patientchat/androidapp/features/WelcomeFragment.kt
@@ -1,4 +1,4 @@
-package com.patientchat.androidapp
+package com.patientchat.androidapp.features
 
 import android.os.Bundle
 import androidx.fragment.app.Fragment
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import androidx.navigation.fragment.findNavController
+import com.patientchat.androidapp.R
 
 /**
  * A simple [Fragment] subclass as the default destination in the navigation.
@@ -25,7 +26,7 @@ class WelcomeFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         view.findViewById<Button>(R.id.button_first).setOnClickListener {
-            findNavController().navigate(R.id.action_FirstFragment_to_SecondFragment)
+            findNavController().navigate(R.id.action_WelcomeFragment_to_AddPatientFragment)
         }
     }
 }

--- a/app/src/main/java/com/patientchat/androidapp/features/patients/AddPatientFragment.kt
+++ b/app/src/main/java/com/patientchat/androidapp/features/patients/AddPatientFragment.kt
@@ -1,18 +1,17 @@
 package com.patientchat.androidapp.features.patients
 
-import android.app.Activity
-import android.content.Intent
 import android.os.Bundle
-import android.text.TextUtils
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
+import android.view.View.OnFocusChangeListener
 import android.view.ViewGroup
 import android.widget.Button
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.Snackbar
 import com.patientchat.androidapp.R
+import com.patientchat.androidapp.core.PatientChatUtils
 import com.patientchat.androidapp.core.PatientViewModel
 import com.patientchat.androidapp.core.db.Patient
 import kotlinx.android.synthetic.main.fragment_add_patient.*
@@ -33,6 +32,12 @@ class AddPatientFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        edittext_patient_name.onFocusChangeListener = OnFocusChangeListener { v, hasFocus ->
+            if (!hasFocus) {
+                PatientChatUtils.hideKeyboard(v)
+            }
+        }
 
         view.findViewById<Button>(R.id.button_next).setOnClickListener {
             var patientName = edittext_patient_name.text.toString()

--- a/app/src/main/java/com/patientchat/androidapp/features/patients/AddPatientFragment.kt
+++ b/app/src/main/java/com/patientchat/androidapp/features/patients/AddPatientFragment.kt
@@ -28,7 +28,6 @@ class AddPatientFragment : Fragment() {
             inflater: LayoutInflater, container: ViewGroup?,
             savedInstanceState: Bundle?
     ): View? {
-        // Inflate the layout for this fragment
         return inflater.inflate(R.layout.fragment_add_patient, container, false)
     }
 
@@ -46,23 +45,5 @@ class AddPatientFragment : Fragment() {
                     .setAction("Action", null).show()
             }
         }
-
-//        val button = findViewById<Button>(R.id.button_save)
-//        button.setOnClickListener {
-//            val replyIntent = Intent()
-//            if (TextUtils.isEmpty(editWordView.text)) {
-//                setResult(Activity.RESULT_CANCELED, replyIntent)
-//            } else {
-//                val word = editWordView.text.toString()
-//                replyIntent.putExtra(EXTRA_REPLY, word)
-//                setResult(Activity.RESULT_OK, replyIntent)
-//            }
-//            finish()
-//        }
-//    }
-//
-//    companion object {
-//        const val EXTRA_REPLY = "com.example.android.wordlistsql.REPLY"
-//    }
     }
 }

--- a/app/src/main/java/com/patientchat/androidapp/features/patients/AddPatientFragment.kt
+++ b/app/src/main/java/com/patientchat/androidapp/features/patients/AddPatientFragment.kt
@@ -1,21 +1,28 @@
-package com.patientchat.androidapp
+package com.patientchat.androidapp.features.patients
 
+import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
+import android.text.TextUtils
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.Snackbar
-import com.patientchat.androidapp.db.Patient
-import kotlinx.android.synthetic.*
+import com.patientchat.androidapp.R
+import com.patientchat.androidapp.core.PatientViewModel
+import com.patientchat.androidapp.core.db.Patient
 import kotlinx.android.synthetic.main.fragment_add_patient.*
 
 /**
  * A simple [Fragment] subclass as the second destination in the navigation.
  */
 class AddPatientFragment : Fragment() {
+
+    private val patientViewModel: PatientViewModel by viewModels()
 
     override fun onCreateView(
             inflater: LayoutInflater, container: ViewGroup?,
@@ -32,14 +39,30 @@ class AddPatientFragment : Fragment() {
             var patientName = edittext_patient_name.text.toString()
             if (patientName.isNotEmpty()) {
                 var patient = Patient.create(patientName)
-                Snackbar.make(view, patient.name+" created", Snackbar.LENGTH_LONG)
-                    .setAction("Action", null).show()
-
+                patientViewModel.insert(patient)
+                findNavController().navigate(R.id.action_AddPatientFragment_to_PatientListFragment)
             } else {
                 Snackbar.make(view, "TODO: Add error handling", Snackbar.LENGTH_LONG)
                     .setAction("Action", null).show()
             }
-            //findNavController().navigate(R.id.action_SecondFragment_to_FirstFragment)
         }
+
+//        val button = findViewById<Button>(R.id.button_save)
+//        button.setOnClickListener {
+//            val replyIntent = Intent()
+//            if (TextUtils.isEmpty(editWordView.text)) {
+//                setResult(Activity.RESULT_CANCELED, replyIntent)
+//            } else {
+//                val word = editWordView.text.toString()
+//                replyIntent.putExtra(EXTRA_REPLY, word)
+//                setResult(Activity.RESULT_OK, replyIntent)
+//            }
+//            finish()
+//        }
+//    }
+//
+//    companion object {
+//        const val EXTRA_REPLY = "com.example.android.wordlistsql.REPLY"
+//    }
     }
 }

--- a/app/src/main/java/com/patientchat/androidapp/features/patients/PatientListAdapter.kt
+++ b/app/src/main/java/com/patientchat/androidapp/features/patients/PatientListAdapter.kt
@@ -14,7 +14,7 @@ class PatientListAdapter internal constructor(
 ) : RecyclerView.Adapter<PatientListAdapter.PatientViewHolder>() {
 
     private val inflater: LayoutInflater = LayoutInflater.from(context)
-    private var patients = emptyList<Patient>() // Cached copy of words
+    private var patients = emptyList<Patient>() // Cached copy of patients
 
     inner class PatientViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val wordItemView: TextView = itemView.findViewById(R.id.textView_name)

--- a/app/src/main/java/com/patientchat/androidapp/features/patients/PatientListAdapter.kt
+++ b/app/src/main/java/com/patientchat/androidapp/features/patients/PatientListAdapter.kt
@@ -1,0 +1,41 @@
+package com.patientchat.androidapp.features.patients
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.patientchat.androidapp.R
+import com.patientchat.androidapp.core.db.Patient
+
+class PatientListAdapter internal constructor(context: Context)
+    : RecyclerView.Adapter<PatientListAdapter.PatientViewHolder>() {
+
+    private val inflater: LayoutInflater = LayoutInflater.from(context)
+    private var patients = listOf<Patient>(Patient.create("Smith"))
+//    private var patients = emptyList<Patient>()
+
+    inner class PatientViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        val patientItemView: TextView = itemView.findViewById(R.id.textView_name)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PatientViewHolder {
+        val itemView = inflater.inflate(R.layout.recyclerview_patient_item, parent, false)
+        return PatientViewHolder(itemView)
+    }
+
+    override fun getItemCount(): Int {
+        patients.size
+    }
+
+    override fun onBindViewHolder(holder: PatientViewHolder, position: Int) {
+        val current = patients[position]
+        holder.patientItemView.text = current.name
+    }
+
+    internal fun setPatients(patients: List<Patient>) {
+        this.patients = patients
+        notifyDataSetChanged()
+    }
+}

--- a/app/src/main/java/com/patientchat/androidapp/features/patients/PatientListAdapter.kt
+++ b/app/src/main/java/com/patientchat/androidapp/features/patients/PatientListAdapter.kt
@@ -9,15 +9,15 @@ import androidx.recyclerview.widget.RecyclerView
 import com.patientchat.androidapp.R
 import com.patientchat.androidapp.core.db.Patient
 
-class PatientListAdapter internal constructor(context: Context)
-    : RecyclerView.Adapter<PatientListAdapter.PatientViewHolder>() {
+class PatientListAdapter internal constructor(
+    context: Context
+) : RecyclerView.Adapter<PatientListAdapter.PatientViewHolder>() {
 
     private val inflater: LayoutInflater = LayoutInflater.from(context)
-    private var patients = listOf<Patient>(Patient.create("Smith"))
-//    private var patients = emptyList<Patient>()
+    private var patients = emptyList<Patient>() // Cached copy of words
 
     inner class PatientViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        val patientItemView: TextView = itemView.findViewById(R.id.textView_name)
+        val wordItemView: TextView = itemView.findViewById(R.id.textView_name)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PatientViewHolder {
@@ -25,17 +25,15 @@ class PatientListAdapter internal constructor(context: Context)
         return PatientViewHolder(itemView)
     }
 
-    override fun getItemCount(): Int {
-        patients.size
-    }
-
     override fun onBindViewHolder(holder: PatientViewHolder, position: Int) {
         val current = patients[position]
-        holder.patientItemView.text = current.name
+        holder.wordItemView.text = current.name
     }
 
-    internal fun setPatients(patients: List<Patient>) {
-        this.patients = patients
+    internal fun setPatients(words: List<Patient>) {
+        this.patients = words
         notifyDataSetChanged()
     }
+
+    override fun getItemCount() = patients.size
 }

--- a/app/src/main/java/com/patientchat/androidapp/features/patients/PatientListFragment.kt
+++ b/app/src/main/java/com/patientchat/androidapp/features/patients/PatientListFragment.kt
@@ -4,21 +4,15 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Button
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.floatingactionbutton.FloatingActionButton
-import com.google.android.material.snackbar.Snackbar
 import com.patientchat.androidapp.R
 import com.patientchat.androidapp.core.PatientViewModel
-import com.patientchat.androidapp.core.db.Patient
-import kotlinx.android.synthetic.main.fragment_add_patient.*
-import kotlinx.android.synthetic.main.fragment_patient_list.*
 
 class PatientListFragment : Fragment() {
 

--- a/app/src/main/java/com/patientchat/androidapp/features/patients/PatientListFragment.kt
+++ b/app/src/main/java/com/patientchat/androidapp/features/patients/PatientListFragment.kt
@@ -1,0 +1,57 @@
+package com.patientchat.androidapp.features.patients
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProviders
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.google.android.material.snackbar.Snackbar
+import com.patientchat.androidapp.R
+import com.patientchat.androidapp.core.PatientViewModel
+import com.patientchat.androidapp.core.db.Patient
+import kotlinx.android.synthetic.main.fragment_add_patient.*
+import kotlinx.android.synthetic.main.fragment_patient_list.*
+
+class PatientListFragment : Fragment() {
+
+    private val patientViewModel: PatientViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_patient_list, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val recyclerView = view.findViewById<RecyclerView>(R.id.recyclerview_patients)
+        val adapter = PatientListAdapter(view.context) // TODO: is this the best way to pass in context?
+        recyclerView.adapter = adapter
+        recyclerView.layoutManager = LinearLayoutManager(context)
+        patientViewModel.allPatients.observe(viewLifecycleOwner, Observer { patients ->
+            patients?.let {
+                adapter.setPatients(it) }
+        })
+
+        view.findViewById<FloatingActionButton>(R.id.fab).setOnClickListener {
+            findNavController().navigate(R.id.action_PatientListFragment_to_AddPatient)
+        }
+    }
+
+
+}

--- a/app/src/main/java/com/patientchat/androidapp/features/patients/PatientListFragment.kt
+++ b/app/src/main/java/com/patientchat/androidapp/features/patients/PatientListFragment.kt
@@ -18,11 +18,6 @@ class PatientListFragment : Fragment() {
 
     private val patientViewModel: PatientViewModel by viewModels()
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-    }
-
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -39,7 +34,11 @@ class PatientListFragment : Fragment() {
         recyclerView.layoutManager = LinearLayoutManager(context)
         patientViewModel.allPatients.observe(viewLifecycleOwner, Observer { patients ->
             patients?.let {
-                adapter.setPatients(it) }
+                if (it.isEmpty()) {
+                    findNavController().navigate(R.id.action_PatientListFragment_to_WelcomeFragment)
+                }
+                adapter.setPatients(it)
+            }
         })
 
         view.findViewById<FloatingActionButton>(R.id.fab).setOnClickListener {

--- a/app/src/main/res/drawable/ic_add_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_add_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    tools:context=".features.MainActivity">
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
@@ -19,14 +19,6 @@
             app:popupTheme="@style/AppTheme.PopupOverlay" />
 
     </com.google.android.material.appbar.AppBarLayout>
-
-<!--    <com.google.android.material.floatingactionbutton.FloatingActionButton-->
-<!--        android:id="@+id/fab"-->
-<!--        android:layout_width="wrap_content"-->
-<!--        android:layout_height="wrap_content"-->
-<!--        android:layout_gravity="bottom|end"-->
-<!--        android:layout_margin="@dimen/fab_margin"-->
-<!--        app:srcCompat="@android:drawable/ic_input_add"/>-->
 
     <include layout="@layout/content_main" />
 

--- a/app/src/main/res/layout/fragment_add_patient.xml
+++ b/app/src/main/res/layout/fragment_add_patient.xml
@@ -4,14 +4,14 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".AddPatientFragment"
+    tools:context=".features.patients.AddPatientFragment"
     android:padding="@dimen/text_margin">
 
     <TextView
         android:id="@+id/textview_second"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/hello_second_fragment"
+        android:text="@string/hello_add_patient_fragment"
         app:layout_constraintBottom_toTopOf="@id/edittext_patient_name"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_add_patient.xml
+++ b/app/src/main/res/layout/fragment_add_patient.xml
@@ -5,6 +5,9 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".features.patients.AddPatientFragment"
+    android:clickable="true"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
     android:padding="@dimen/text_margin">
 
     <TextView

--- a/app/src/main/res/layout/fragment_patient_list.xml
+++ b/app/src/main/res/layout/fragment_patient_list.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerview_patients"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        tools:listitem="@layout/recyclerview_patient_item"
+        android:padding="@dimen/text_margin"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/fab_margin"
+        android:contentDescription="@string/add_patient"
+        android:src="@drawable/ic_add_black_24dp"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_welcome.xml
+++ b/app/src/main/res/layout/fragment_welcome.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".WelcomeFragment">
+    tools:context=".features.WelcomeFragment">
 
     <Button
         android:id="@+id/button_first"
@@ -20,7 +20,7 @@
         android:id="@+id/textview_first"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/hello_first_fragment"
+        android:text="@string/hello_welcome_fragment"
         app:layout_constraintBottom_toTopOf="@id/button_first"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/recyclerview_patient_item.xml
+++ b/app/src/main/res/layout/recyclerview_patient_item.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/textView_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+</LinearLayout>

--- a/app/src/main/res/layout/recyclerview_patient_item.xml
+++ b/app/src/main/res/layout/recyclerview_patient_item.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical" android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
 
     <TextView
         android:id="@+id/textView_name"

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -3,6 +3,11 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:context="com.patientchat.androidapp.features.MainActivity">
     <item
+        android:id="@+id/action_clear_patients"
+        android:orderInCategory="100"
+        android:title="@string/action_clear_patients"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/action_settings"
         android:orderInCategory="100"
         android:title="@string/action_settings"

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -1,7 +1,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context="com.patientchat.androidapp.MainActivity">
+    tools:context="com.patientchat.androidapp.features.MainActivity">
     <item
         android:id="@+id/action_settings"
         android:orderInCategory="100"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -34,7 +34,7 @@
 
         <action
             android:id="@+id/action_PatientListFragment_to_WelcomeFragment"
-            app:destination="@id/AddPatientFragment" />
+            app:destination="@id/WelcomeFragment" />
         <action
             android:id="@+id/action_PatientListFragment_to_AddPatient"
             app:destination="@id/AddPatientFragment" />

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -3,26 +3,40 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph"
-    app:startDestination="@id/FirstFragment">
+    app:startDestination="@id/PatientListFragment">
+<!--    app:startDestination="@id/WelcomeFragment">-->
 
     <fragment
-        android:id="@+id/FirstFragment"
-        android:name="com.patientchat.androidapp.WelcomeFragment"
+        android:id="@+id/WelcomeFragment"
+        android:name="com.patientchat.androidapp.features.WelcomeFragment"
         android:label="@string/welcome_fragment_label"
         tools:layout="@layout/fragment_welcome">
 
         <action
-            android:id="@+id/action_FirstFragment_to_SecondFragment"
-            app:destination="@id/SecondFragment" />
+            android:id="@+id/action_WelcomeFragment_to_AddPatientFragment"
+            app:destination="@id/AddPatientFragment" />
     </fragment>
     <fragment
-        android:id="@+id/SecondFragment"
-        android:name="com.patientchat.androidapp.AddPatientFragment"
+        android:id="@+id/AddPatientFragment"
+        android:name="com.patientchat.androidapp.features.patients.AddPatientFragment"
         android:label="@string/add_patient_fragment_label"
         tools:layout="@layout/fragment_add_patient">
 
         <action
-            android:id="@+id/action_SecondFragment_to_FirstFragment"
-            app:destination="@id/FirstFragment" />
+            android:id="@+id/action_AddPatientFragment_to_PatientListFragment"
+            app:destination="@id/PatientListFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/PatientListFragment"
+        android:name="com.patientchat.androidapp.features.patients.PatientListFragment"
+        android:label="@string/patient_list_fragment_label"
+        tools:layout="@layout/fragment_patient_list">
+
+        <action
+            android:id="@+id/action_PatientListFragment_to_WelcomeFragment"
+            app:destination="@id/AddPatientFragment" />
+        <action
+            android:id="@+id/action_PatientListFragment_to_AddPatient"
+            app:destination="@id/AddPatientFragment" />
     </fragment>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,14 +5,18 @@
     <!-- Strings used for fragments for navigation -->
     <string name="welcome_fragment_label">Welcome Fragment</string>
     <string name="add_patient_fragment_label">Add Patient Fragment</string>
+    <string name="patient_list_fragment_label">Patient List Fragment</string>
 
-    <!--    Welcome fragment-->
-    <string name="hello_first_fragment">Welcome to Patient Chat.</string>
+    <!--    Welcome fragment  -->
+    <string name="hello_welcome_fragment">Welcome to Patient Chat.</string>
     <string name="add_first_patient">Add First Patient</string>
 
-    <!--    Add Patient fragment-->
-    <string name="hello_second_fragment">Add your patient now.</string>
+    <!--    Add Patient fragment  -->
+    <string name="hello_add_patient_fragment">Add your patient now.</string>
     <string name="patient_name_hint">Patient Name</string>
     <string name="next">Next</string>
+
+    <!--    List fragment  -->
+    <string name="add_patient">Add Patient</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name">Patient Chat</string>
+    <string name="action_clear_patients">Clear Patients</string>
     <string name="action_settings">Settings</string>
 
     <!-- Strings used for fragments for navigation -->

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.Light.DarkActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
@@ -17,4 +17,11 @@
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
+    <style name="patient_title">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_marginBottom">8dp</item>
+        <item name="android:paddingLeft">8dp</item>
+        <item name="android:background">@android:color/holo_orange_light</item>
+        <item name="android:textAppearance">@android:style/TextAppearance.Large</item>
+    </style>
 </resources>

--- a/app/src/test/java/com/patientchat/androidapp/PatientUnitTest.kt
+++ b/app/src/test/java/com/patientchat/androidapp/PatientUnitTest.kt
@@ -1,6 +1,6 @@
 package com.patientchat.androidapp
 
-import com.patientchat.androidapp.db.Patient
+import com.patientchat.androidapp.core.db.Patient
 import org.junit.Test
 
 import org.junit.Assert.*

--- a/build.gradle
+++ b/build.gradle
@@ -27,3 +27,11 @@ allprojects {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+
+ext {
+    roomVersion = '2.2.5'
+    archLifecycleVersion = '2.2.0'
+    coreTestingVersion = '2.1.0'
+    materialVersion = '1.1.0'
+    coroutines = '1.3.4'
+}


### PR DESCRIPTION
This commit adds in the room architectural component, and live updates via viewmodels. Patients can be added to the database, and are shown on a very simple list view. There is an option in the menu to clear the patient database.

Additionally:
- Navigation is improved (app starts at list view, and only goes to welcome if there are no patients saved in the database).
- Keyboard on Add Patient fragment now closes when focus changes
- General cleanup has been done. 